### PR TITLE
Restore TX A-MPDU support

### DIFF
--- a/esp_mac80211.c
+++ b/esp_mac80211.c
@@ -1200,11 +1200,14 @@ void esp_op_flush(struct ieee80211_hw *hw, struct ieee80211_vif *vif,
 
 static int esp_op_ampdu_action(struct ieee80211_hw *hw,
 			       struct ieee80211_vif *vif,
-			       enum ieee80211_ampdu_mlme_action action,
-			       struct ieee80211_sta *sta, u16 tid,
-			       u16 * ssn, u8 buf_size, bool amsdu)
+			       struct ieee80211_ampdu_params *params)
 {
 	int ret = -EOPNOTSUPP;
+	enum ieee80211_ampdu_mlme_action action = params->action;
+	struct ieee80211_sta *sta = params->sta;
+	u16 tid = params->tid;
+	u16 *ssn = &params->ssn;
+	u8 buf_size = params->buf_size;
 	struct esp_pub *epub = (struct esp_pub *) hw->priv;
 	struct esp_node *node = (struct esp_node *) sta->drv_priv;
 	struct esp_tx_tid *tid_info = &node->tid[tid];

--- a/esp_mac80211.c
+++ b/esp_mac80211.c
@@ -1235,25 +1235,6 @@ static int esp_op_ampdu_action(struct ieee80211_hw *hw,
 		ieee80211_start_tx_ba_cb_irqsafe(vif, sta->addr, tid);
 		spin_unlock_bh(&epub->tx_ampdu_lock);
 		ret = 0;
-		spin_lock_bh(&epub->tx_ampdu_lock);
-
-		if (tid_info->state != ESP_TID_STATE_PROGRESS) {
-			if (tid_info->state == ESP_TID_STATE_INIT) {
-				printk(KERN_ERR "%s WIFI RESET, IGNORE\n",
-				       __func__);
-				spin_unlock_bh(&epub->tx_ampdu_lock);
-				return -ENETRESET;
-			} else {
-				ESSERT(0);
-			}
-		}
-
-		tid_info->state = ESP_TID_STATE_OPERATIONAL;
-		spin_unlock_bh(&epub->tx_ampdu_lock);
-		ret =
-		    sip_send_ampdu_action(epub, SIP_AMPDU_TX_OPERATIONAL,
-					  sta->addr, tid, node->ifidx,
-					  buf_size);
 		break;
 	case IEEE80211_AMPDU_TX_STOP_CONT:
 		ESP_IEEE80211_DBG(ESP_DBG_ERROR,

--- a/esp_mac80211.c
+++ b/esp_mac80211.c
@@ -1198,6 +1198,141 @@ void esp_op_flush(struct ieee80211_hw *hw, struct ieee80211_vif *vif,
 	} while (0);
 }
 
+static int esp_op_ampdu_action(struct ieee80211_hw *hw,
+			       struct ieee80211_vif *vif,
+			       enum ieee80211_ampdu_mlme_action action,
+			       struct ieee80211_sta *sta, u16 tid,
+			       u16 * ssn, u8 buf_size, bool amsdu)
+{
+	int ret = -EOPNOTSUPP;
+	struct esp_pub *epub = (struct esp_pub *) hw->priv;
+	struct esp_node *node = (struct esp_node *) sta->drv_priv;
+	struct esp_tx_tid *tid_info = &node->tid[tid];
+
+	ESP_IEEE80211_DBG(ESP_DBG_OP, "%s enter \n", __func__);
+	switch (action) {
+	case IEEE80211_AMPDU_TX_START:
+		if (mod_support_no_txampdu() ||
+		    cfg80211_get_chandef_type(&epub->hw->conf.chandef) ==
+		    NL80211_CHAN_NO_HT || !sta->ht_cap.ht_supported)
+			return ret;
+
+		//if (vif->p2p || vif->type != NL80211_IFTYPE_STATION)
+		//      return ret;
+
+		ESP_IEEE80211_DBG(ESP_DBG_ERROR,
+				  "%s TX START, addr:%pM,tid:%u,state:%d\n",
+				  __func__, sta->addr, tid,
+				  tid_info->state);
+		spin_lock_bh(&epub->tx_ampdu_lock);
+		ESSERT(tid_info->state == ESP_TID_STATE_TRIGGER);
+		*ssn = tid_info->ssn;
+		tid_info->state = ESP_TID_STATE_PROGRESS;
+
+		ieee80211_start_tx_ba_cb_irqsafe(vif, sta->addr, tid);
+		spin_unlock_bh(&epub->tx_ampdu_lock);
+		ret = 0;
+		spin_lock_bh(&epub->tx_ampdu_lock);
+
+		if (tid_info->state != ESP_TID_STATE_PROGRESS) {
+			if (tid_info->state == ESP_TID_STATE_INIT) {
+				printk(KERN_ERR "%s WIFI RESET, IGNORE\n",
+				       __func__);
+				spin_unlock_bh(&epub->tx_ampdu_lock);
+				return -ENETRESET;
+			} else {
+				ESSERT(0);
+			}
+		}
+
+		tid_info->state = ESP_TID_STATE_OPERATIONAL;
+		spin_unlock_bh(&epub->tx_ampdu_lock);
+		ret =
+		    sip_send_ampdu_action(epub, SIP_AMPDU_TX_OPERATIONAL,
+					  sta->addr, tid, node->ifidx,
+					  buf_size);
+		break;
+	case IEEE80211_AMPDU_TX_STOP_CONT:
+		ESP_IEEE80211_DBG(ESP_DBG_ERROR,
+				  "%s TX STOP, addr:%pM,tid:%u,state:%d\n",
+				  __func__, sta->addr, tid,
+				  tid_info->state);
+		spin_lock_bh(&epub->tx_ampdu_lock);
+		if (tid_info->state == ESP_TID_STATE_WAIT_STOP)
+			tid_info->state = ESP_TID_STATE_STOP;
+		else
+			tid_info->state = ESP_TID_STATE_INIT;
+		ieee80211_stop_tx_ba_cb_irqsafe(vif, sta->addr, tid);
+		spin_unlock_bh(&epub->tx_ampdu_lock);
+		ret =
+		    sip_send_ampdu_action(epub, SIP_AMPDU_TX_STOP,
+					  sta->addr, tid, node->ifidx, 0);
+		break;
+	case IEEE80211_AMPDU_TX_STOP_FLUSH:
+	case IEEE80211_AMPDU_TX_STOP_FLUSH_CONT:
+		if (tid_info->state == ESP_TID_STATE_WAIT_STOP)
+			tid_info->state = ESP_TID_STATE_STOP;
+		else
+			tid_info->state = ESP_TID_STATE_INIT;
+		ret =
+		    sip_send_ampdu_action(epub, SIP_AMPDU_TX_STOP,
+					  sta->addr, tid, node->ifidx, 0);
+		break;
+	case IEEE80211_AMPDU_TX_OPERATIONAL:
+		ESP_IEEE80211_DBG(ESP_DBG_ERROR,
+				  "%s TX OPERATION, addr:%pM,tid:%u,state:%d\n",
+				  __func__, sta->addr, tid,
+				  tid_info->state);
+		spin_lock_bh(&epub->tx_ampdu_lock);
+
+		if (tid_info->state != ESP_TID_STATE_PROGRESS) {
+			if (tid_info->state == ESP_TID_STATE_INIT) {
+				printk(KERN_ERR "%s WIFI RESET, IGNORE\n",
+				       __func__);
+				spin_unlock_bh(&epub->tx_ampdu_lock);
+				return -ENETRESET;
+			} else {
+				ESSERT(0);
+			}
+		}
+
+		tid_info->state = ESP_TID_STATE_OPERATIONAL;
+		spin_unlock_bh(&epub->tx_ampdu_lock);
+		ret =
+		    sip_send_ampdu_action(epub, SIP_AMPDU_TX_OPERATIONAL,
+					  sta->addr, tid, node->ifidx,
+					  buf_size);
+		break;
+	case IEEE80211_AMPDU_RX_START:
+		if (mod_support_no_rxampdu() ||
+		    cfg80211_get_chandef_type(&epub->hw->conf.chandef) ==
+		    NL80211_CHAN_NO_HT || !sta->ht_cap.ht_supported)
+			return ret;
+
+		if ((vif->p2p && false)
+		    || (vif->type != NL80211_IFTYPE_STATION && false)
+		    )
+			return ret;
+		ESP_IEEE80211_DBG(ESP_DBG_ERROR,
+				  "%s RX START %pM tid %u %u\n", __func__,
+				  sta->addr, tid, *ssn);
+		ret =
+		    sip_send_ampdu_action(epub, SIP_AMPDU_RX_START,
+					  sta->addr, tid, *ssn, 64);
+		break;
+	case IEEE80211_AMPDU_RX_STOP:
+		ESP_IEEE80211_DBG(ESP_DBG_ERROR, "%s RX STOP %pM tid %u\n",
+				  __func__, sta->addr, tid);
+		ret =
+		    sip_send_ampdu_action(epub, SIP_AMPDU_RX_STOP,
+					  sta->addr, tid, 0, 0);
+		break;
+	default:
+		break;
+	}
+	return ret;
+}
+
 static void esp_tx_work(struct work_struct *work)
 {
 	struct esp_pub *epub = container_of(work, struct esp_pub, tx_work);
@@ -1239,6 +1374,7 @@ static const struct ieee80211_ops esp_mac80211_ops = {
 	.remain_on_channel = esp_op_remain_on_channel,
 	.cancel_remain_on_channel = esp_op_cancel_remain_on_channel,
 #endif
+	.ampdu_action = esp_op_ampdu_action,
 	//.get_survey = esp_op_get_survey,
 	.sta_add = esp_op_sta_add,
 	.sta_remove = esp_op_sta_remove,


### PR DESCRIPTION
During cleanup of ifdef guards for older kernels in
commit b34bfa40566f ("mac80211 I forgot the No. ... Terrible esp"),
a block of code meant for Linux kernels < v2.6.28 was accidently
left in place.

The effect was that an AMPDU_TX_OPERATIONAL message was sent down
to the firmware for an AMPDU_TX_START notification from mac80211,
in addition to triggering assertion messages in both the driver and
the firmware.  This may have had additional side effects, too.

For reasons not entirely clear to me, this rendered TX completely
unoperational.

These patches restores the behavior before the cleanups and fixes
compatibility with Linux 4.6 and newer.
